### PR TITLE
Feature Dataset: fix: minor fix & change to getitem return order

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -54,7 +54,7 @@ class AudioDataset(Dataset):
         """
         if sr != self.sample_rate_target:
 
-            resampler = torchaudio.transforms.Resample(sr, self.sample_rate_target)
+            resampler = torchaudio.transforms.Resample(sr, self.sample_rate_target).to(self.device)
             signal = resampler(signal)
       
         return signal
@@ -100,7 +100,7 @@ class AudioDataset(Dataset):
         signal = self._mix_down_if_needed(signal)
         signal = self.transformations(signal)
 
-        return filename, signal, label, identifier
+        return signal, label, filename, identifier
     
     
     def _get_audio_sample_path(self, index):


### PR DESCRIPTION
# Pull Request Feature Dataset #2 bugfix 
# Description
In order to make retrieval easier the order of getitem return should be: signal, label, filename, identifier
Fixed minor bug
# Changes Made
Changed return value of the getitem method to: signal, label, filename, identifier
Added .to(device) in the dataset resampler.
# Related Issue
Resampler was in the wrong device.

