### PR TITLE
Launch params feat: casting types from json

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -43,7 +43,30 @@ def parse_json(args, parser):
     if args.json != '':
         with open(args.json, 'rt') as f:
             t_args = argparse.Namespace()
-            t_args.__dict__.update(json.load(f))
+            param_json = json.load(f)
+            for key, value in param_json.items():
+                param_json[key] = casttype(value)
+            t_args.__dict__.update(param_json)
             args = parser.parse_args(namespace=t_args)
     return args
 
+def casttype(value):
+    type = value.find(')')
+    if type == -1:
+        print("There may be missing types in the json file, assuming str")
+        return value
+    elif value[:type] == '(str':
+        return value[type+1:]
+    elif value[:type] == '(int':
+        return int(value[type+1:])
+    elif value[:type] == '(float':
+        return float(value[type+1:])
+    elif value[:type] == '(bool':
+        return bool(value[type+1:])
+    elif value[:type] == '(list':
+        return list(value[type+1:])
+    elif value[:type] == '(tuple':
+        return tuple(value[type+1:])
+    else:
+        print("Unknown type in json file, assuming str")
+        return value


### PR DESCRIPTION
# Pull Request Feature launch params 
# Description

Parameters json now has to include the type of the parameter in between parenthesis 
{
"optimizer":"(str)Adam"
}

# Changes Made

Added a method to parse the string and cast it to the correct type.

# Related Issue
Wrong types in parameters.

# Known Issues
If requirements change there may be a need to just eval() the string as it is.